### PR TITLE
Fix three code bugs

### DIFF
--- a/alacritty.toml
+++ b/alacritty.toml
@@ -24,5 +24,5 @@ cyan    = "#ffbe74"
 white   = "#11AEB3"
 
 [colors.cursor]
-text   = "#ff7f41"
+text   = "#0e091d"
 cursor = "#ff7f41"

--- a/ghostty.conf
+++ b/ghostty.conf
@@ -1,25 +1,22 @@
-# primary
-background = #0e091d
-foreground = #14B9B5
-cursor-color = #ff7f41
-cursor-text = #ff7f41
+"background" = "#0e091d"
+"foreground" = "#14B9B5"
+"cursor-color" = "#ff7f41"
+"cursor-text" = "#0e091d"
 
-# normal colors
-palette = 0=#000000
-palette = 1=#c8e967
-palette = 2=#E20342
-palette = 3=#7cd699
-palette = 4=#BE3F50
-palette = 5=#9147a8
-palette = 6=#FF7F41
-palette = 7=#A60234
+palette = 0: #000000
+palette = 1: #c8e967
+palette = 2: #E20342
+palette = 3: #7cd699
+palette = 4: #BE3F50
+palette = 5: #9147a8
+palette = 6: #FF7F41
+palette = 7: #A60234
 
-# bright colors
-palette = 8=#c53253
-palette = 9=#CE4F48
-palette = 10=#f93d3b
-palette = 11=#FD3E6A
-palette = 12=#04C5F0
-palette = 13=#6C032C
-palette = 14=#ffbe74
-palette = 15=#11AEB3
+palette = 8: #c53253
+palette = 9: #CE4F48
+palette = 10: #f93d3b
+palette = 11: #FD3E6A
+palette = 12: #04C5F0
+palette = 13: #6C032C
+palette = 14: #ffbe74
+palette = 15: #11AEB3

--- a/hyprland.conf
+++ b/hyprland.conf
@@ -1,5 +1,5 @@
 # focus window color (border)
 general {
-    col.active_border = rgb(e20342) rgb(c8e967) 45deg
-    col.inactive_border = rgb(2a153c)
+    col.active_border = 0xffe20342 0xffc8e967 45deg
+    col.inactive_border = 0xff2a153c
 }


### PR DESCRIPTION
Fix invalid color syntax in Hyprland and Ghostty configurations, and improve cursor text contrast in Alacritty and Ghostty.

---
<a href="https://cursor.com/background-agent?bcId=bc-12d27c80-1dd5-4343-8836-55d2cdacc6ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-12d27c80-1dd5-4343-8836-55d2cdacc6ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

