### PR TITLE
fix for "line 49 invalid fied noscreenshare: missing a value"

### DIFF
--- a/hyprland.conf
+++ b/hyprland.conf
@@ -45,7 +45,7 @@ animations {
 }
 
 # Protects private windows during screensharing (others will see black window)
-windowrule = noscreenshare, class:proton-authenticator
-windowrule = noscreenshare, title:Proton Authenticator
+windowrule2 = noscreenshare, class:proton-authenticator
+windowrule2  = noscreenshare, title:Proton Authenticator
 
 bindd = SUPER+ALT, BACKSPACE, Toggle dimming, exec, ~/.config/omarchy/themes/aetheria/dimming.sh


### PR DESCRIPTION
<img width="1909" height="58" alt="image" src="https://github.com/user-attachments/assets/a4febd81-ea89-434a-8862-01d65a1be28a" />

Updated `windowrule` to `windowrule2` on lines 48 and 49 in `hyprland.conf`.
 This fixes the msg show in image 
 
> Config error in file .../omarchy/current/theme/hypniand.conf at line 48: invalid fied noscreenshare: missing a value
> Config error in file .../omarchy/current/theme/hypriand.conf at line 49: invalid fied noscreenshare: missing a value
> Config error in file .../hypr/hypriand.conf at line 13: Config error in file .../omarchy/current/theme/hypriand.conf at line 48: invalid fied noscreenshare: missing a value
> Config error in file .../omarchy/current/theme/hypriand.conf at line 49: invalid fied noscreenshare: missing a value

I believe error caused by recent Hyprland updates.